### PR TITLE
Break text on whole words

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,9 +2,9 @@ general:
   artifacts:
     - docs
     - preview
-dependencies:
-  pre:
-    - nvm install 8
+machine:
+  node:
+    version: 8.8.1
 test:
   override:
     - npm test

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ general:
     - preview
 dependencies:
   pre:
-    - case $CIRCLE_NODE_INDEX in 0) nvm use 4.2 ;; 1) nvm use 5.7 ;; 2) nvm use 6.1 ;; esac
+    - nvm use 8.8
 test:
   override:
     - npm test

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ general:
     - preview
 dependencies:
   pre:
-    - nvm use 8.8
+    - nvm install 8
 test:
   override:
     - npm test

--- a/circle.yml
+++ b/circle.yml
@@ -2,13 +2,23 @@ general:
   artifacts:
     - docs
     - preview
+
 machine:
+  environment:
+    PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
   node:
     version: 8.8.1
+
+dependencies:
+  override:
+    - yarn install --pure-lockfile
+  cache_directories:
+    - ~/.cache/yarn
+
 test:
   override:
-    - npm test
-    - npm run test:sauce
+    - yarn test
+
 deployment:
   preview:
     branch: /.*/

--- a/preview/index.html
+++ b/preview/index.html
@@ -45,6 +45,11 @@ Lorem ipsum dolor sit amet, convenire iracundia ex ius, his at ipsum invidunt. E
                 <input type="button" data-y-alignment="bottom" value="bottom" />
                 <br/>
 
+                <label>Wrap Break</label>
+                <input type="button" data-word-break="true" value="character" />
+                <input type="button" data-word-break="false" value="word" />
+                <br/>
+
             </div>
             <div class="fill-half-right">
                 <h5>SVG</h5>

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -9,6 +9,7 @@ function createSvgUpdater(selector, options) {
     const writeOptions = Object(options);
 
     const update = function() {
+        typesetter.wrapper.allowBreakingWords(this.options.wordBreak);
         element.innerHTML = "";
         typesetter.write(this.text, BOX_WIDTH, BOX_HEIGHT, this.options);
     };
@@ -42,6 +43,7 @@ function createCanvasUpdater(selector, options) {
     const writeOptions = Object(options);
 
     const update = function() {
+        typesetter.wrapper.allowBreakingWords(this.options.wordBreak);
         const rect = writeOptions.rect == null ? element.getBoundingClientRect() : writeOptions.rect;
         ctx.save();
         ctx.fillStyle = "white";
@@ -67,6 +69,7 @@ function createHtmlUpdater(selector, options) {
     const writeOptions = Object(options);
 
     const update = function() {
+        typesetter.wrapper.allowBreakingWords(this.options.wordBreak);
         element.innerHTML = "";
         typesetter.write(this.text, BOX_WIDTH, BOX_HEIGHT, this.options);
     };
@@ -144,6 +147,17 @@ Array.prototype.forEach.call(document.querySelectorAll("input[data-y-alignment]"
     button.addEventListener("click", () => {
         configurables.forEach((configurable) => {
             configurable.options.yAlign = button.getAttribute("data-y-alignment");
+            configurable.update.apply(configurable);
+    });
+    });
+});
+
+// bind word break
+Array.prototype.forEach.call(document.querySelectorAll("input[data-word-break]"), (button) => {
+    button.addEventListener("click", () => {
+        configurables.forEach((configurable) => {
+            configurable.options.wordBreak = button.getAttribute("data-word-break") === "true";
+            console.log(configurable.options.wordBreak);
             configurable.update.apply(configurable);
     });
     });

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -157,7 +157,6 @@ Array.prototype.forEach.call(document.querySelectorAll("input[data-word-break]")
     button.addEventListener("click", () => {
         configurables.forEach((configurable) => {
             configurable.options.wordBreak = button.getAttribute("data-word-break") === "true";
-            console.log(configurable.options.wordBreak);
             configurable.update.apply(configurable);
     });
     });

--- a/src/utils/tokenizer.ts
+++ b/src/utils/tokenizer.ts
@@ -24,7 +24,7 @@ export class Tokenizer {
       return [token + newCharacter];
     } else if (this.WhitespaceRegExp.test(lastCharacter) || this.WhitespaceRegExp.test(newCharacter)) {
       return [token, newCharacter];
-    } else if (!(this.WordDividerRegExp.test(lastCharacter) || this.WordDividerRegExp.test(newCharacter))) {
+    } else if (!(this.WordDividerRegExp.test(lastCharacter))) { // || this.WordDividerRegExp.test(newCharacter))) {
       return [token + newCharacter];
     } else if (lastCharacter === newCharacter) {
       return [token + newCharacter];

--- a/src/utils/tokenizer.ts
+++ b/src/utils/tokenizer.ts
@@ -24,7 +24,7 @@ export class Tokenizer {
       return [token + newCharacter];
     } else if (this.WhitespaceRegExp.test(lastCharacter) || this.WhitespaceRegExp.test(newCharacter)) {
       return [token, newCharacter];
-    } else if (!(this.WordDividerRegExp.test(lastCharacter))) { // || this.WordDividerRegExp.test(newCharacter))) {
+    } else if (!(this.WordDividerRegExp.test(lastCharacter))) {
       return [token + newCharacter];
     } else if (lastCharacter === newCharacter) {
       return [token + newCharacter];

--- a/src/wrappers/wrapper.ts
+++ b/src/wrappers/wrapper.ts
@@ -45,7 +45,7 @@ export class Wrapper {
   constructor() {
     this.maxLines(Infinity);
     this.textTrimming("ellipsis");
-    this.allowBreakingWords(true);
+    this.allowBreakingWords(false);
     this._tokenizer = new Utils.Tokenizer();
     this._breakingCharacter = "-";
   }

--- a/src/wrappers/wrapper.ts
+++ b/src/wrappers/wrapper.ts
@@ -145,9 +145,7 @@ export class Wrapper {
   }
 
   private canFitToken(token: string, width: number, measurer: Measurers.AbstractMeasurer) {
-    const possibleBreaks = this._allowBreakingWords ?
-                          token.split("").map((c, i) => (i !== token.length - 1) ? c + this._breakingCharacter : c)
-                          : [token];
+    const possibleBreaks = token.split("").map((c, i) => (i !== token.length - 1) ? c + this._breakingCharacter : c);
     return (measurer.measure(token).width <= width) || possibleBreaks.every((c) => measurer.measure(c).width <= width);
   }
 
@@ -223,7 +221,6 @@ export class Wrapper {
     // Token is really long, but we have a space to put part of the word.
     if (state.canFitText &&
         state.availableLines !== state.wrapping.noLines &&
-        this._allowBreakingWords &&
         this._textTrimming !== "none") {
       const res = this.addEllipsis(state.currentLine + token, state.availableWidth, measurer);
       state.wrapping.wrappedText += res.wrappedToken;
@@ -267,7 +264,8 @@ export class Wrapper {
       };
     }
 
-    if (!this._allowBreakingWords) {
+    // if we don't allow breaking words AND the token isn't the only thing on the current line.
+    if (!this._allowBreakingWords && line.trim() !== "") {
       return {
         breakWord: false,
         line,

--- a/test/tokenizerTests.ts
+++ b/test/tokenizerTests.ts
@@ -33,27 +33,27 @@ describe("Tokenizer Test Suite", () => {
   });
 
   it("word divider", () => {
-    const multipleWords = ["hello", ",", "world"];
+    const multipleWords = ["hello,", "world"];
     const tokens = tokenizer.tokenize(multipleWords.join(""));
-    assert.deepEqual(tokens, multipleWords, "Word divider is separate token");
+    assert.deepEqual(tokens, multipleWords, "Word divider is not a separate token");
   });
 
   it("word divider + whitespace", () => {
-    const multipleWords = ["hello", ",", "world", " "];
+    const multipleWords = ["hello,", " ", "world", " "];
     const tokens = tokenizer.tokenize(multipleWords.join(""));
-    assert.deepEqual(tokens, multipleWords, "Word divider and whitespace are separate tokens");
+    assert.deepEqual(tokens, multipleWords, "Word divider are same token but whitespace are separate");
   });
 
   it("mutliple word divider", () => {
-    const multipleWords = ["hello", ",,", "world"];
+    const multipleWords = ["hello,,", " ", "world"];
     const tokens = tokenizer.tokenize(multipleWords.join(""));
     assert.deepEqual(tokens, multipleWords, "Mutliple same word dividers are the same token");
   });
 
   it("different word dividers", () => {
-    const multipleWords = ["hello", ",", ";", "world"];
+    const multipleWords = ["hello,", ";", " ", "world"];
     const tokens = tokenizer.tokenize(multipleWords.join(""));
-    assert.deepEqual(tokens, multipleWords, "Different word dividers are not the same token");
+    assert.deepEqual(tokens, multipleWords, "Different word dividers are the same token");
   });
 
   it("all whitespaces are same token", () => {

--- a/test/wrapperTests.ts
+++ b/test/wrapperTests.ts
@@ -86,20 +86,34 @@ describe("Wrapper Test Suite", () => {
       const result = wrapper.wrap(token, measurer, availableWidth);
       assert.deepEqual(result.originalText, token, "original text has been set");
       assert.lengthOf(result.wrappedText.split("\n"), 2, "wrapping occured");
-      assert.deepEqual(result.truncatedText, "", "non of the text has been truncated");
+      assert.deepEqual(result.truncatedText, "", "none of the text has been truncated");
       assert.deepEqual(result.noBrokeWords, 1, "wrapping with breaking one word");
       assert.deepEqual(result.noLines, 2, "wrapping was needed");
       assert.operator(measurer.measure(result.wrappedText).width, "<=", availableWidth, "wrapped text fits in");
     });
 
-    it("no breaking words", () => {
-      const availableWidth = measurer.measure(token).width * 3 / 4;
+    it("disable breaking words", () => {
       wrapper.allowBreakingWords(false);
+      const wrappableToken = "hello world";
+      const availableWidth = measurer.measure(wrappableToken).width * 3 / 4;
+      const result = wrapper.wrap(wrappableToken, measurer, availableWidth);
+      assert.lengthOf(result.wrappedText.split("\n"), 2, "wrapping occured");
+      assert.notInclude(result.wrappedText, "-", "no hyphenation");
+      assert.deepEqual(result.truncatedText, "", "none of the text has been truncated");
+      assert.deepEqual(result.noBrokeWords, 0, "no broken words");
+      assert.deepEqual(result.noLines, 2, "wrapping was needed");
+      assert.operator(measurer.measure(result.wrappedText).width, "<=", availableWidth, "wrapped text fits in");
+    });
+
+    it("disable breaking words, except as last resort", () => {
+      wrapper.allowBreakingWords(false);
+      const availableWidth = measurer.measure(token).width * 3 / 4;
       const result = wrapper.wrap(token, measurer, availableWidth);
-      assert.equal(result.wrappedText, "", "wrapping was impossible");
-      assert.deepEqual(result.truncatedText, token, "whole text has been truncated");
-      assert.deepEqual(result.noBrokeWords, 0, "no breaks");
-      assert.deepEqual(result.noLines, 0, "wrapped text has no lines");
+      assert.lengthOf(result.wrappedText.split("\n"), 2, "wrapping occured");
+      assert.deepEqual(result.truncatedText, "", "non of the text has been truncated");
+      assert.deepEqual(result.noBrokeWords, 1, "wrapping with breaking one word");
+      assert.deepEqual(result.noLines, 2, "wrapping was needed");
+      assert.operator(measurer.measure(result.wrappedText).width, "<=", availableWidth, "wrapped text fits in");
     });
 
     it.skip("multi time wrapping", () => {

--- a/test/wrapperTests.ts
+++ b/test/wrapperTests.ts
@@ -50,7 +50,7 @@ describe("Wrapper Test Suite", () => {
     });
 
     it("allow breaking words", () => {
-      assert.isTrue(wrapper.allowBreakingWords(), "allow breaking words has been set to default");
+      assert.isFalse(wrapper.allowBreakingWords(), "allow breaking words has been disabled to default");
     });
   });
 
@@ -62,6 +62,7 @@ describe("Wrapper Test Suite", () => {
     });
 
     it("does not wrap", () => {
+      wrapper.allowBreakingWords(true);
       const dimensions = measurer.measure(token);
       const result = wrapper.wrap(token, measurer, dimensions.width * 2);
       assert.deepEqual(result.originalText, token, "original text has been set");
@@ -72,6 +73,7 @@ describe("Wrapper Test Suite", () => {
     });
 
     it("does not wrap becasue of height", () => {
+      wrapper.allowBreakingWords(true);
       const dimensions = measurer.measure(token);
       const result = wrapper.wrap(token, measurer, dimensions.width, dimensions.height / 2);
       assert.deepEqual(result.originalText, token, "original text has been set");
@@ -82,6 +84,7 @@ describe("Wrapper Test Suite", () => {
     });
 
     it("one time wrapping", () => {
+      wrapper.allowBreakingWords(true);
       const availableWidth = measurer.measure(token).width * 3 / 4;
       const result = wrapper.wrap(token, measurer, availableWidth);
       assert.deepEqual(result.originalText, token, "original text has been set");
@@ -92,8 +95,7 @@ describe("Wrapper Test Suite", () => {
       assert.operator(measurer.measure(result.wrappedText).width, "<=", availableWidth, "wrapped text fits in");
     });
 
-    it("disable breaking words", () => {
-      wrapper.allowBreakingWords(false);
+    it("does not break words", () => {
       const wrappableToken = "hello world";
       const availableWidth = measurer.measure(wrappableToken).width * 3 / 4;
       const result = wrapper.wrap(wrappableToken, measurer, availableWidth);
@@ -105,8 +107,7 @@ describe("Wrapper Test Suite", () => {
       assert.operator(measurer.measure(result.wrappedText).width, "<=", availableWidth, "wrapped text fits in");
     });
 
-    it("disable breaking words, except as last resort", () => {
-      wrapper.allowBreakingWords(false);
+    it("does not break words, except as last resort", () => {
       const availableWidth = measurer.measure(token).width * 3 / 4;
       const result = wrapper.wrap(token, measurer, availableWidth);
       assert.lengthOf(result.wrappedText.split("\n"), 2, "wrapping occured");
@@ -117,6 +118,7 @@ describe("Wrapper Test Suite", () => {
     });
 
     it.skip("multi time wrapping", () => {
+      wrapper.allowBreakingWords(true);
       const availableWidth = measurer.measure("h-").width;
       const result = wrapper.wrap(token, measurer, availableWidth);
       assert.deepEqual(result.originalText, token, "original text has been set");
@@ -128,6 +130,7 @@ describe("Wrapper Test Suite", () => {
     });
 
     it("wrapping is impossible", () => {
+      wrapper.allowBreakingWords(true);
       const availableWidth = measurer.measure("h").width - 0.1;
       const result = wrapper.wrap(token, measurer, availableWidth);
       assert.deepEqual(result.originalText, token, "original text has been set");
@@ -138,6 +141,7 @@ describe("Wrapper Test Suite", () => {
     });
 
     it("only first sign fits", () => {
+      wrapper.allowBreakingWords(true);
       const tokenWithSmallFirstSign = "aHHH";
       const availableWidth = measurer.measure("a-").width;
       const result = wrapper.wrap(tokenWithSmallFirstSign, measurer, availableWidth);
@@ -157,6 +161,7 @@ describe("Wrapper Test Suite", () => {
     });
 
     it("does not wrap", () => {
+      wrapper.allowBreakingWords(true);
       const dimensions = measurer.measure(line);
       const result = wrapper.wrap(line, measurer, dimensions.width * 2);
       assert.deepEqual(result.originalText, line, "original text has been set");
@@ -166,9 +171,8 @@ describe("Wrapper Test Suite", () => {
       assert.equal(result.noLines, 1, "no wrapping was needed");
     });
 
-    it("no breaking words", () => {
+    it("does not break words", () => {
       const availableWidth = measurer.measure(line).width * 0.75;
-      wrapper.allowBreakingWords(false);
       const result = wrapper.wrap(line, measurer, availableWidth);
       assert.deepEqual(result.originalText, line, "original text has been set");
       assert.lengthOf(result.wrappedText.split("\n"), 2, "wrapping occured");
@@ -190,6 +194,7 @@ describe("Wrapper Test Suite", () => {
     });
 
     it("one time wrapping", () => {
+      wrapper.allowBreakingWords(true);
       const availableWidth = measurer.measure(line).width * 0.75;
       const result = wrapper.wrap(line, measurer, availableWidth);
       assert.deepEqual(result.originalText, line, "original text has been set");
@@ -273,6 +278,7 @@ describe("Wrapper Test Suite", () => {
     });
 
     it("one time wrapping", () => {
+      wrapper.allowBreakingWords(true);
       const availableWidth = measurer.measure(lines).width * 0.75;
       const result = wrapper.wrap(lines, measurer, availableWidth);
       assert.deepEqual(result.originalText, lines, "original text has been set");
@@ -316,6 +322,7 @@ describe("Wrapper Test Suite", () => {
 
     it("one time wrapping", () => {
       const lines = text.split("\n");
+      wrapper.allowBreakingWords(true);
       wrapper.maxLines(2);
       const availableWidth = measurer.measure(text).width * 0.75;
       const result = wrapper.wrap(text, measurer, availableWidth);
@@ -329,6 +336,7 @@ describe("Wrapper Test Suite", () => {
 
     it("in the middle of line", () => {
       const availableWidth = measurer.measure(text).width * 0.75;
+      wrapper.allowBreakingWords(true);
       wrapper.maxLines(3);
       const result = wrapper.wrap(text, measurer, availableWidth);
       assert.deepEqual(result.originalText, text, "original text has been set");
@@ -380,6 +388,7 @@ describe("Wrapper Test Suite", () => {
     });
 
     it("handling whitespaces", () => {
+      wrapper.allowBreakingWords(true);
       text = "this            aa";
       const availableWidth = measurer.measure(text).width - 1;
       const result = wrapper.wrap(text, measurer, availableWidth);
@@ -401,6 +410,7 @@ describe("Wrapper Test Suite", () => {
     });
 
     it("multiple token", () => {
+      wrapper.allowBreakingWords(true);
       text = "hello world!";
       const availableWidth = measurer.measure("hello worl-").width;
       const result = wrapper.wrap(text, measurer, availableWidth);
@@ -414,6 +424,7 @@ describe("Wrapper Test Suite", () => {
     });
 
     it("multiple lines", () => {
+      wrapper.allowBreakingWords(true);
       text = "hello  world!.\nhello  world!.";
       const availableWidth = measurer.measure("hello worl-").width;
       const result = wrapper.wrap(text, measurer, availableWidth);

--- a/yarn.lock
+++ b/yarn.lock
@@ -241,12 +241,6 @@ abbrev@1, abbrev@1.0.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
 
-accessory@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/accessory/-/accessory-1.0.1.tgz#25954a258291a21b1be8f1902064e962cee6ce62"
-  dependencies:
-    dot-parts "~1.0.0"
-
 acorn@^1.0.3:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-1.2.2.tgz#c8ce27de0acc76d896d2b1fad3df588d9e82f014"
@@ -547,16 +541,6 @@ browserify-rsa@^4.0.0:
   dependencies:
     bn.js "^4.1.0"
     randombytes "^2.0.1"
-
-browserify-shim@^3.8.12:
-  version "3.8.13"
-  resolved "https://registry.yarnpkg.com/browserify-shim/-/browserify-shim-3.8.13.tgz#701e5744f1c4a9d62576d61cf304ed97c7289319"
-  dependencies:
-    exposify "~0.4.3"
-    mothership "~0.2.0"
-    rename-function-calls "~0.1.0"
-    resolve "~0.6.1"
-    through "~2.3.4"
 
 browserify-sign@^4.0.0:
   version "4.0.0"
@@ -1275,20 +1259,13 @@ des.js@^1.0.0:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
 
-detective@^4.0.0, detective@~4.1.0:
+detective@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/detective/-/detective-4.1.1.tgz#9c4bac1e9fb8bb34f7f18cae080ea1d03aff2cda"
   dependencies:
     acorn "^1.0.3"
     defined "^1.0.0"
     escodegen "^1.4.1"
-
-detective@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/detective/-/detective-3.1.0.tgz#77782444ab752b88ca1be2e9d0a0395f1da25eed"
-  dependencies:
-    escodegen "~1.1.0"
-    esprima-fb "3001.1.0-dev-harmony-fb"
 
 diff@1.4.0:
   version "1.4.0"
@@ -1309,10 +1286,6 @@ diffie-hellman@^5.0.0:
 domain-browser@~1.1.0:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
-
-dot-parts@~1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dot-parts/-/dot-parts-1.0.1.tgz#884bd7bcfc3082ffad2fe5db53e494d8f3e0743f"
 
 dot-prop@^3.0.0:
   version "3.0.0"
@@ -1389,7 +1362,7 @@ escape-string-regexp@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz#4dbc2fe674e71949caf3fb2695ce7f2dc1d9a8d1"
 
-escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.3:
+escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -1404,20 +1377,6 @@ escodegen@1.8.x, escodegen@^1.4.1:
   optionalDependencies:
     source-map "~0.2.0"
 
-escodegen@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.1.0.tgz#c663923f6e20aad48d0c0fa49f31c6d4f49360cf"
-  dependencies:
-    esprima "~1.0.4"
-    estraverse "~1.5.0"
-    esutils "~1.0.0"
-  optionalDependencies:
-    source-map "~0.1.30"
-
-esprima-fb@3001.1.0-dev-harmony-fb:
-  version "3001.1.0-dev-harmony-fb"
-  resolved "https://registry.yarnpkg.com/esprima-fb/-/esprima-fb-3001.0001.0000-dev-harmony-fb.tgz#b77d37abcd38ea0b77426bb8bc2922ce6b426411"
-
 esprima@2.7.x, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
@@ -1426,25 +1385,13 @@ esprima@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
-esprima@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-1.0.4.tgz#9f557e08fc3b4d26ece9dd34f8fbf476b62585ad"
-
 estraverse@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.9.3.tgz#af67f2dc922582415950926091a4005d29c9bb44"
 
-estraverse@~1.5.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.5.1.tgz#867a3e8e58a9f84618afb6c2ddbcd916b7cbaf71"
-
 esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
-
-esutils@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-1.0.0.tgz#8151d358e20c8acc7fb745e7472c0025fe496570"
 
 event-stream@~3.3.0:
   version "3.3.4"
@@ -1483,17 +1430,6 @@ expand-range@^1.8.1:
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
   dependencies:
     fill-range "^2.1.0"
-
-exposify@~0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/exposify/-/exposify-0.4.3.tgz#1963eb34c489f8bfba02dfd27fccfbc117384c9e"
-  dependencies:
-    globo "~1.0.0"
-    has-require "~1.1.0"
-    map-obj "~1.0.1"
-    replace-requires "~1.0.1"
-    through2 "~0.4.0"
-    transformify "~0.1.1"
 
 extend@3, extend@~3.0.0:
   version "3.0.0"
@@ -1554,10 +1490,6 @@ fill-range@^2.1.0:
 filled-array@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/filled-array/-/filled-array-1.1.0.tgz#c3c4f6c663b923459a9aa29912d2d031f1507f84"
-
-find-parent-dir@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -1736,14 +1668,6 @@ glob@^7.0.0, glob@^7.0.5, glob@^7.1.0, glob@^7.1.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globo@~1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/globo/-/globo-1.0.2.tgz#68f75ce2a045440d3a704131786f88d4205f49bd"
-  dependencies:
-    accessory "~1.0.0"
-    is-defined "~1.0.0"
-    ternary "~1.0.0"
-
 got@^5.0.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/got/-/got-5.7.1.tgz#5f81635a61e4a6589f180569ea4e381680a51f35"
@@ -1814,16 +1738,6 @@ has-ansi@^2.0.0:
 has-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-
-has-require@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/has-require/-/has-require-1.1.0.tgz#41e3e8bb8623467893edbc3909a5893de52c76f8"
-
-has-require@~1.2.1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/has-require/-/has-require-1.2.2.tgz#921675ab130dbd9768fc8da8f1a8e242dfa41774"
-  dependencies:
-    escape-string-regexp "^1.0.3"
 
 has-unicode@^2.0.0:
   version "2.0.1"
@@ -2002,10 +1916,6 @@ is-callable@^1.1.1, is-callable@^1.1.3:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
-
-is-defined@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-defined/-/is-defined-1.0.0.tgz#1f07ca67d571f594c4b14415a45f7bef88f92bf5"
 
 is-dotfile@^1.0.0:
   version "1.0.2"
@@ -2368,10 +2278,6 @@ lru-cache@^4.0.0, lru-cache@^4.0.1:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
-map-obj@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
-
 map-stream@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/map-stream/-/map-stream-0.1.0.tgz#e56aa94c4c8055a16404a0674b78f215f7c8e194"
@@ -2567,12 +2473,6 @@ module-deps@^4.0.8:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-mothership@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/mothership/-/mothership-0.2.0.tgz#93d48a2fbc3e50e2a5fc8ed586f5bc44c65f9a99"
-  dependencies:
-    find-parent-dir "~0.3.0"
-
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -2657,10 +2557,6 @@ object-assign@^4.0.1, object-assign@^4.1.0:
 object-keys@^1.0.6, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
-
-object-keys@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -2785,10 +2681,6 @@ parse-json@^2.1.0, parse-json@^2.2.0:
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
     error-ex "^1.2.0"
-
-patch-text@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/patch-text/-/patch-text-1.0.2.tgz#4bf36e65e51733d6e98f0cf62e09034daa0348ac"
 
 path-browserify@~0.0.0:
   version "0.0.0"
@@ -2991,7 +2883,7 @@ read-pkg@^1.0.0, read-pkg@^1.1.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-"readable-stream@>=1.0.33-1 <1.1.0-0", readable-stream@~1.0.17:
+"readable-stream@>=1.0.33-1 <1.1.0-0":
   version "1.0.34"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
   dependencies:
@@ -3011,15 +2903,6 @@ readable-stream@^2.0.0, "readable-stream@^2.0.0 || ^1.1.13", readable-stream@^2.
     process-nextick-args "~1.0.6"
     string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
-
-readable-stream@~1.1.9:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
 
 readable-stream@~2.0.0:
   version "2.0.6"
@@ -3078,12 +2961,6 @@ registry-url@^3.0.3:
   dependencies:
     rc "^1.0.1"
 
-rename-function-calls@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/rename-function-calls/-/rename-function-calls-0.1.1.tgz#7f83369c007a3007f6abe3033ccf81686a108e01"
-  dependencies:
-    detective "~3.1.0"
-
 repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
@@ -3097,15 +2974,6 @@ repeating@^2.0.0:
   resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
   dependencies:
     is-finite "^1.0.0"
-
-replace-requires@~1.0.1:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/replace-requires/-/replace-requires-1.0.3.tgz#73e85df05bab562fe84df45d97d78c0fa13a7041"
-  dependencies:
-    detective "~4.1.0"
-    has-require "~1.2.1"
-    patch-text "~1.0.2"
-    xtend "~4.0.0"
 
 request-progress@~2.0.1:
   version "2.0.1"
@@ -3149,10 +3017,6 @@ resolve@1.1.7, resolve@1.1.x:
 resolve@^1.1.3, resolve@^1.1.4, resolve@^1.1.6, resolve@^1.1.7:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.2.0.tgz#9589c3f2f6149d1417a40becc1663db6ec6bc26c"
-
-resolve@~0.6.1:
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-0.6.3.tgz#dd957982e7e736debdf53b58a4dd91754575dd46"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -3270,12 +3134,6 @@ sntp@1.x.x:
 source-map@^0.4.4, source-map@~0.4.2:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
-  dependencies:
-    amdefine ">=0.0.4"
-
-source-map@~0.1.30:
-  version "0.1.43"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
   dependencies:
     amdefine ">=0.0.4"
 
@@ -3479,10 +3337,6 @@ tar@~2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
-ternary@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ternary/-/ternary-1.0.0.tgz#45702725608c9499d46a9610e9b0e49ff26f789e"
-
 throttleit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/throttleit/-/throttleit-1.0.0.tgz#9e785836daf46743145a5984b6268d828528ac6c"
@@ -3494,13 +3348,6 @@ through2@^2.0.0:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through2@~0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/through2/-/through2-0.4.2.tgz#dbf5866031151ec8352bb6c4db64a2292a840b9b"
-  dependencies:
-    readable-stream "~1.0.17"
-    xtend "~2.1.1"
-
 through2@~0.6.1, through2@~0.6.5:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/through2/-/through2-0.6.5.tgz#41ab9c67b29d57209071410e1d7a7a968cd3ad48"
@@ -3508,7 +3355,7 @@ through2@~0.6.1, through2@~0.6.5:
     readable-stream ">=1.0.33-1 <1.1.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
-through@2, "through@>=2.2.7 <3", through@~2.3, through@~2.3.1, through@~2.3.4:
+through@2, "through@>=2.2.7 <3", through@~2.3, through@~2.3.1:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -3535,12 +3382,6 @@ tough-cookie@~2.3.0:
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.2.tgz#f081f76e4c85720e6c37a5faced737150d84072a"
   dependencies:
     punycode "^1.4.1"
-
-transformify@~0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/transformify/-/transformify-0.1.2.tgz#9a4f42a154433dd727b80575428a3c9e5489ebf1"
-  dependencies:
-    readable-stream "~1.1.9"
 
 tree-kill@~1.1.0:
   version "1.1.0"
@@ -3789,15 +3630,9 @@ xmlhttprequest@1:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 
-"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.0, xtend@~4.0.1:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
-
-xtend@~2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
-  dependencies:
-    object-keys "~0.4.0"
 
 yallist@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Modify logic of `Wrapper` to better wrap whole words when `wrapper.allowBreakingWords` is set to `false`.
    
Also, include punctuation in tokens to prevent single character punctuation from wrapping to its own line.
    
Update preview and unit tests to confirm new behavior.

#### New wrap example
Given the string and the available space (`|---|`):
```
"Hello, world!"
|-------|
```
Previously this would wrap like so:
```
|-------|
Hello, w-
orld!
```

With this change, we now wrap like so:
```
|-------|
Hello,
world!
```

The old behavior can still be used by setting `wrapper.allowBreakingWords(true);`

#### Last resort breaking

Notably, a single word that does not fit in one line may still be broken and hyphenated. like so:

```
"A very longwordthatdoesntfit"
|------|
A very
longwor-
dthatdo-
esntfit
```

#### Punctuation

Additionally, we now consider punctuation to be part of the previous token. This prevents single character punctuation such as "," or "." from being wrapped to its own line.

Previous:
```
|-----|
A comma
, too.
```

New
```
|-----|
A
comma,
too.
```

