### PR TITLE
change GitHub token name, remove unapproved Action config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - restore_cache: *restore-node-modules-cache
       - attach_workspace: { at: "." }
       - run: npm run preview:bundle
-      - run: ./preview/demo.js
+      - run: ./scripts/submit-comment-with-artifact-links.js
       - store_artifacts: { path: docs }
       - store_artifacts: { path: preview }
 

--- a/.github/actions/collect-circleci-artifact-links.mjs
+++ b/.github/actions/collect-circleci-artifact-links.mjs
@@ -1,0 +1,1 @@
+console.log("Unimplemented");

--- a/.github/actions/collect-circleci-artifact-links.yml
+++ b/.github/actions/collect-circleci-artifact-links.yml
@@ -1,0 +1,23 @@
+name: 'collect-circleci-artifact-links'
+description: Collect CircleCI artifact links
+author: adahiya@palantir.com
+inputs:
+  github-api-token:
+    description: 'GitHub API token'
+    required: true
+  artifact-path:
+    description: 'Local file path to the CircleCI artifact'
+    required: true
+  circleci-job-name:
+    description: 'Name of CircleCI job to monitor'
+    required: true
+  job-title:
+    description: 'The name of this job, as it will render on the PR GUI (default is "<name of CI job> artifact")'
+    required: false
+outputs:
+  url:
+    description: 'The full artifact URL'
+on: push
+runs:
+  using: 'node16'
+  main: '.github/actions/collect-circleci-artifact-links.mjs'

--- a/.github/workflows/pr-preview-artifacts.yml
+++ b/.github/workflows/pr-preview-artifacts.yml
@@ -5,23 +5,9 @@ jobs:
     if: "${{ github.event.context == 'ci/circleci: preview' }}"
     name: Collect CircleCI artifact links
     steps:
-      - name: Docs preview artifact
-        id: step1
-        uses: larsoner/circleci-artifacts-redirector-action@master
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3.6.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-path: 0/docs/index.html
-          circleci-jobs: preview
-          job-title: View docs artifact
-      - name: Preview artifact
-        id: step2
-        uses: larsoner/circleci-artifacts-redirector-action@master
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          artifact-path: 0/preview/index.html
-          circleci-jobs: preview
-          job-title: View preview artifact
-      - name: Check the URL
-        if: github.event.status != 'pending'
-        run: |
-          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA
+          node-version: 16
+          cache: yarn
+      - uses: ./.github/actions/collect-circleci-artifact-links

--- a/scripts/submit-comment-with-artifact-links.js
+++ b/scripts/submit-comment-with-artifact-links.js
@@ -7,7 +7,9 @@ demos = [
     bot.artifactLink('preview/index.html', 'dev'),
 ];
 
-bot.comment(process.env.GH_AUTH_TOKEN, `
+bot.comment(process.env.GITHUB_API_TOKEN, `
 <h3>${bot.commitMessage()}</h3>
-Preview: <strong>${demos.join(' | ')}</strong>
+Build artifact links for this commit: <strong>${demos.join(' | ')}</strong>
+
+<em>This is an automated comment from the preview CircleCI job.</em>
 `);


### PR DESCRIPTION
It looks like I can't use https://github.com/marketplace/actions/run-circleci-artifacts-redirector without getting org approval first. It might make more sense to write our own custom action and share that across our FE repos. Will do that eventually.

For now, just to get this build working again, I'm going to re-use the `GITHUB_API_TOKEN` token from Blueprint and call it a day... we'll need to come back and fix this up properly if typesettable ever needs to publish again.